### PR TITLE
Convert adviqotech/adviser-app to GitHub Actions

### DIFF
--- a/.github/workflows/adviser-app.yml
+++ b/.github/workflows/adviser-app.yml
@@ -1,0 +1,136 @@
+name: adviqotech/adviser-app
+on:
+  push:
+  workflow_dispatch:
+concurrency:
+  group: "${{ github.ref }}"
+  cancel-in-progress: true
+env:
+  FIREBASE_TOKEN: 1//093jc3QR9nZlNCgYIARAAGAkSNwF-L9Ir6mkhvlr8uT7AHK7cVJjGSvlR9cyM8ix_A-Z6iVR7adI5fiCu9lFjB78uoH9FqBiV4Ms
+  COMMITTOKEN: xBD5cZhAKECbhjdcezax
+  PASSWORD: adviqo
+  ANDROID_RELEASE_KEY: MIIKOwIBAzCCCfQGCSqGSIb3DQEHAaCCCeUEggnhMIIJ3TCCBXEGCSqGSIb3DQEHAaCCBWIEggVeMIIFWjCCBVYGCyqGSIb3DQEMCgECoIIE+zCCBPcwKQYKKoZIhvcNAQwBAzAbBBS3/m7Mdg++AEOAjYGhj90xkgZgOwIDAMNQBIIEyIoMy6u/59oUGeMVGHgAv3TqCKwsOc+HliC9urUM1kyOyIYjrs4cfOPyizjyjpVYnoZrSidckSK6zgF7MQeWiiFvZjB/NuppVXXGvIgTp14MihhDeJtCRtf6R/aN71VxlKJv9mYUURGGU/nwmhtDPlVsXIcqq5DIvRBSY2Ea9Y9Aq0Jj4aKrmiFQw9UYIMEBtx+iiAMmRoLoqAD/5z040hdl8ZQaLPAqXH+2aqMfYgNCwGy+YBoqAHWtqP4vM1ng8yFjmk3OtlqXEdKTJTaqMryAbShjKPKdUwzNZyUPPi5LIJ8CFZtRAH7El6wPERiLOtwjTE8g9R0tdx5JImMnJ4WsaxaNa+SW6ED8AmR8GzGVNndsxzUjshW/iXGi+/ffpOgrEIWBBxfbwTUqFAcLIUr0EVK4Mn+/UNviMiejBz1Qrk4xqODQMLEpZHQLcJ0a9zXHUp5p/Y+6Y+BSacmI6U2OQcBIDSyJfeGxDbbKZAzJQGnHcZF9lb28AnuU78Bz5sOXeMaCELDU+7QSFvh65MMFoxbiMwHY6qDaTTnyExLBNnXBfvdvPhXRLuqJIIRfOBcK8LFswZgKjLXiqBoEetx5okTCU3VY/R8kPGI/IWtFUbR6/0XyOkl9ZkayXGgaRXnx91Tpmzylpqsn7jKZlmgnslTn3M/kZsduUq0a61fNeV3ZzTohB9Oe3HsnJIWQwdBxE8W/F5nOJ7YIMxIE49+XcfaUW2zgntQt3y+4iMQ+gudpUjKoObnOuEaE4xEfOtcePyIJveeq0kMRsSUD6eCcEK4vubpaUgirs+uTrICHWO5zqoxiM7ueWSk4xC3BmMcQCS712vkbmr6XLJ55h79ohLPM+3i9dm3Z19BbZIDpZj1k4+sAVsme907ym3tsFE/IjLMxrO7BVChQshPKT6K7m/HTcbpwzAHMgRm+Jg9Re+QI35Va77vlXv38ZIo1na8H350RNpVmVP9Skota4qScBFOTfCakjgJdGNF75/3Y+vuwvWjVQ1HSqDgLtkEfw1X9rEXJMW4SjfD6lbAWIy5i0jpreCizm4Zy7rPfEVibIgZ5mzbxp5N79IoziVLnNi3xGpGWALZPXAdyfZD8JXye4PxO18f1TAHT3FbvXpOtLZjzBinwnJIiQ9llOl75dTr0ML8OdgCXxNB/QJSEFxMDF1hlvAyMk/qtLAE3iXH2fzRHnXX1ykkpOU5MQm4illmzF2JNVoxn+nM5oQSkanzA090MBksiwIKS09iAAhi1CpWg/qxUl6ZbKBAKVOX7BuTsh4Nyrdgzl5yFPHFtQMDqNqdA1NQMyXea7W51IdRc0B9cAPHhsiQzgCGcZMX49A23QHzRX2EqC2awaOEqJY7lUgEnBbt5uIr4MN7vhomnX2X5mrNp2tK9e8t6nu0JEC+z3HAzboFeLZYe+Kwq0prlgbbTWTiSqUi+ZiMtubLs408t7s7lOHD21DBtpMi60uWSYOpjI5Df0/2SQI2Je7I3EvdYYIGPbB6vBpVkyMp4M4nxPEdtWMpbn5w03cPfxEDzI/XZQcpwLclA+le7YpPiyXeGGnlwEMzOtl14kkvoVZG7UxeX754OHtjqfSGAUfSZ4Mgl7OSe/bR9KKIdtfY34o5VDbaigTFIMCMGCSqGSIb3DQEJFDEWHhQAcAByAG8AZAB1AGMAdABpAG8AbjAhBgkqhkiG9w0BCRUxFAQSVGltZSAxNjM0NzM3NDg2MjIzMIIEZAYJKoZIhvcNAQcGoIIEVTCCBFECAQAwggRKBgkqhkiG9w0BBwEwKQYKKoZIhvcNAQwBBjAbBBRSYnGUc2IOBlhjl4iW+nfKk0xEwwIDAMNQgIIEEFhRS5B3P9lCPepebhivliHV3ZoNRY7XKfEuuYYZ0tNg5TWQTQi1qzD5KpPvTnk/ggvPNRVo3mSUJ7QNR4ph3yogwb60qX3/ondH3lXokZw85Q60zy8+BwHr6L360w+7baJQxIBjrQV8s60mxJmPHF5qD5XjTmx9wACpVUHVN/PKzJNIVQED9GCTHA3HvTOaLr3Fd5qO5X+2cBR86SN/NzM8ARBg/iDry06KNy+LE3DC6tk0xwyih9iwvC7DibfmvbkFRkL3Gvo/FPRtwwvmD0zGGD+R5rpvq8vguR8Rp71gtBbDoWQBo73HVSoRkUJ9YyZLEEqPzoEHlYpkc9jzrJpT/qf7yTYXe+NM8S4cVPE9zRk8UGBn+m1p3lA9kHuKC3lkAy8ndiOq1fL0MWbvNNr2JbAPpZWsMKEEMm2tA1TGfCNudrNsaPY9LNs3xXX7Ql2PiKRtlkiEZpSsTdTunUZh7X9E+G0BhzgvSjyXzwivZxM/94AxF80tMhZEShrtj84uQJkWHgcv3EWlwRDnzoVfgZdTkkpe2PWj2zaeXkwCuxmzYz+W7pKLn5p2YrLjGR7L8UCdxYi88zlwb1vpjMRChhtLMj84cfipifKh0szOhFpAbNBWus9FJzC6cFnxcNKTkeOskCpycCgL2tHyXcJqe1Po9ykfdU6eroFMd06z+oQZ71LQoJ187zU75pcwUgGzKQkZPpGKT+I57siTwBsh5RF1mb05z2Ik0udPYVno3/L7bdJeNcBYClYmPbXU16kpap2TVRxZ3zJwks/TcTp1zh/FjSS4lTsHHXvPeoJYnu1wR489Tl4ydnPjWfCjrfTtraTp3zdlCkXklG/zTHcyeZHqmaH5Jl44RH9Bie5G3GtPjvAHxbzZl0c+H/3BlzhJf7NSu6BRj5rUydKz/TE0j/ixK/tnd6ZA2+4NMlyjhUJU+FEEoG8hQQOX9JI+vw2m4OlBxa9WZjO8IwxEU5wVIEEz76TVZwhcyxIUp/5wl9EN4qGyDBmTvoWWfvLXFSYAPIGu4BjIfDPFc4bkgkRxY6OnJ8GlUa7d1cg+V8Ux21WX0L/sDmhCa4yeXDOHjVP8CThpLJ1PAGnJML3wGOjZHi2yOG3DUCrSPv5q71vFkeuSxs1SMv6DL3Dcely7ma6Jf9ZNujbffg3P3C5dwjXkYgjbQY63wssLlvvr2XLs3MClH1VDpeonoV7R1TjpE/i6dIjIumyARuVT2U36Jvh6kEjQh6TO4pzeT98fsB15dJEQKjzEqNtu1z2UQ14BvFsPgw4PR8+5PIkuGwoi7m3c1ge2jFcDBn4G9ayixS/5PqFOFjXQ4b04SKxEuRRL7vh7jepfaIRa4Ld/Nc3tSaY8tYhKw42XVUrzoBrHwDhOMD4wITAJBgUrDgMCGgUABBQjzVFMHM3gX07+fk8oLtyrQNBnZAQUNvoDFDwqrYckECxlDdQHxEbQZCoCAwGGoA==
+jobs:
+  upgrade_flutter:
+    runs-on:
+      - self-hosted
+      - macmini
+    if: startsWith(github.ref, 'refs/heads')
+    timeout-minutes: 60
+    env:
+      LANG: en_US.UTF-8
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - run: flutter upgrade
+    - run: flutter channel stable
+    - run: flutter --version
+  build-ios:
+    needs: upgrade_flutter
+    runs-on:
+      - self-hosted
+      - macmini
+    if: startsWith(github.ref, 'refs/heads')
+    timeout-minutes: 60
+    env:
+      LANG: en_US.UTF-8
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - run: flutter --version
+    - run: flutter pub get
+    - run: flutter pub run build_runner build --delete-conflicting-outputs
+    - run: flutter build ipa --release --export-method development
+    - uses: actions/upload-artifact@v3.1.3
+      if: success()
+      with:
+        name: "${{ github.job }}"
+        path: build/ios/ipa/*
+  build-android:
+    needs: upgrade_flutter
+    runs-on:
+      - self-hosted
+      - macmini
+    if: startsWith(github.ref, 'refs/heads')
+    timeout-minutes: 60
+    env:
+      LANG: en_US.UTF-8
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - run: printf ${ANDROID_RELEASE_KEY} | base64 -d > ./android/keys/release.keystore
+    - run: flutter --version
+    - run: flutter pub get
+    - run: flutter pub run build_runner build --delete-conflicting-outputs
+    - run: flutter build appbundle --release
+    - uses: actions/upload-artifact@v3.1.3
+      if: success()
+      with:
+        name: "${{ github.job }}"
+        path: build/app/outputs/bundle/release/app-release.aab
+  generate-release-notes:
+    needs:
+    - build-ios
+    - build-android
+    runs-on:
+      - self-hosted
+      - macmini
+    if: github.ref == 'refs/heads/develop'
+    timeout-minutes: 60
+    env:
+      LANG: en_US.UTF-8
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - uses: actions/download-artifact@v3.0.2
+    - run: git fetch origin ${{ github.event.pull_request.base.ref }}
+    - run: git log --pretty="- %s (%h)" $CI_COMMIT_BEFORE_SHA..${{ github.sha }} > release-notes.txt
+    - uses: actions/upload-artifact@v3.1.3
+      if: success()
+      with:
+        name: "${{ github.job }}"
+        path: release-notes.txt
+  deploy-ios:
+    needs:
+    - build-ios
+    - generate-release-notes
+    runs-on:
+      - self-hosted
+      - macmini
+    if: github.ref == 'refs/heads/develop'
+    timeout-minutes: 60
+    env:
+      LANG: en_US.UTF-8
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - uses: actions/download-artifact@v3.0.2
+    - run: firebase appdistribution:distribute "build/ios/ipa/Advisor App.ipa" --app 1:986930839057:ios:931a04b3aeb905de5cbbb0 --token "$FIREBASE_TOKEN" --release-notes-file release-notes.txt --groups "Testers" --debug
+  deploy-android:
+    needs:
+    - build-android
+    - generate-release-notes
+    runs-on:
+      - self-hosted
+      - macmini
+    if: github.ref == 'refs/heads/develop'
+    timeout-minutes: 60
+    env:
+      LANG: en_US.UTF-8
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 50
+        lfs: true
+    - uses: actions/download-artifact@v3.0.2
+    - run: firebase appdistribution:distribute build/app/outputs/bundle/release/app-release.aab --app 1:986930839057:android:16ca6e7b357f2ba95cbbb0 --token "$FIREBASE_TOKEN" --release-notes-file release-notes.txt --groups "Testers" --debug


### PR DESCRIPTION
Pipeline migrated from [GitLab](https://gitlab.com/adviqotech/adviser-app) :tada:

## Manual steps

Perform the following steps to complete the migration:

### adviqotech/adviser-app
- [ ] Ensure a runner with the following labels exists: macmini